### PR TITLE
Fixed package loading

### DIFF
--- a/cm-incudine.asd
+++ b/cm-incudine.asd
@@ -12,12 +12,13 @@
                #:fudi)
   :serial t
   :components ((:module "src"
-                         :serial t
-                         :components ((:file "incudine")
-                                      (:file "incudine-rts")
-                                      (:file "rt")
-                                      (:file "osc")
-                                      (:file "fudi")
-                                      (:file "jackmidi")
-                                      (:file "io")
-                                      (:file "exports")))))
+                :serial t
+                :components ((:file "package")
+                             (:file "incudine")
+                             (:file "incudine-rts")
+                             (:file "rt")
+                             (:file "osc")
+                             (:file "fudi")
+                             (:file "jackmidi")
+                             (:file "io")
+                             (:file "exports")))))


### PR DESCRIPTION
The file 'src/package.lisp' is missing from 'cm-incudine.asd' and hence the package definition never gets loaded. This commit fixes this.