### PR TITLE
Added PortMidi support

### DIFF
--- a/cm-incudine.asd
+++ b/cm-incudine.asd
@@ -18,7 +18,10 @@
                                       (:file "rt")
                                       (:file "osc")
                                       (:file "fudi")
+                                      #-portaudio
                                       (:file "jackmidi")
+                                      #+portaudio
+                                      (:file "portmidi")
                                       (:file "io")
                                       (:file "cm-incudine-import")
                                       (:file "exports")))))

--- a/src/exports.lisp
+++ b/src/exports.lisp
@@ -6,8 +6,8 @@
    *midi-in1*
    *midi-out1*
    *stream-recv-responders*
-   *jackmidi-rcv-type-dummy*
-   *jackmidi-obj-name-dummy*
+   *midi-rcv-type-dummy*
+   *midi-obj-name-dummy*
    status->opcode
    status->channel
    make-mm-mask

--- a/src/fudi.lisp
+++ b/src/fudi.lisp
@@ -7,7 +7,7 @@
 ;;; modify it under the terms of the Gnu Public License, version 2 or
 ;;; later. See https://www.gnu.org/licenses/gpl-2.0.html for the text
 ;;; of this agreement.
-;;; 
+;;;
 ;;; This program is distributed in the hope that it will be useful,
 ;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -48,7 +48,7 @@
                                     :protocol protocol
                                     :element-type element-type
                                     :direction :input))
-         (fudi::start-socket-server *fudi-in*))))) 
+         (fudi::start-socket-server *fudi-in*)))))
 
 (defun fudi-open (&key
                     (host "127.0.0.1") (port 3001)
@@ -110,11 +110,11 @@
 
 ;;; dummy method to make set-receiver! happy
 (defmethod rt-stream-receive-type ((stream fudi:input-stream))
-  *jackmidi-rcv-type-dummy*)
+  *midi-rcv-type-dummy*)
 
 ;;; dummy method to make set-receiver! happy
 (defmethod object-name ((stream fudi:input-stream))
-  *jackmidi-obj-name-dummy*)
+  *midi-obj-name-dummy*)
 
 (defmethod rt-stream-receive-data ((stream fudi:input-stream))
   (declare (ignore stream))

--- a/src/io.lisp
+++ b/src/io.lisp
@@ -13,7 +13,8 @@
           (if type (setf (rt-stream-receive-type stream) type)
               (if (and (not (rt-stream-receive-type stream))
                        (not (member (type-of stream)
-                                    '(fudi::input-stream jackmidi:input-stream))))
+                                    '(fudi::input-stream #-portaudio jackmidi:input-stream
+                                                         #+portaudio pm:input-stream))))
                   (setf (rt-stream-receive-type stream)
                           *receive-type*)))
           (stream-receive-init stream hook args)
@@ -25,4 +26,3 @@
              "set-receiver!: ~s does not support :receive-type ~s."
              stream (rt-stream-receive-type stream))))
           (values)))))
-


### PR DESCRIPTION
I've updated this package so it works with portmidi. Unfortunately I don't have jackmidi so I can't test if it still works with jackmidi. I _think_ it should, but obviously that should be tested.

I also changed the exports so that instead of being *jackmidi...* they now say *midi...* I'm happy to change that back to the way it was if that causes problems, but it felt strange for that variable to be *jackmidi* if it could be portmidi.

Happy to make any additional changes you need in order to get this merged.